### PR TITLE
Fix broken checkout

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -83,8 +83,9 @@ class AssetCheckoutController extends Controller
                 $company_id = $request->get('company_id');
             }
 
+            $status_id = '';
             if ($request->filled('status_id')) {
-                $asset->status_id = $request->get('status_id');
+                $status_id = $request->get('status_id');
             }
 
             if(!empty($asset->licenseseats->all())){
@@ -96,7 +97,7 @@ class AssetCheckoutController extends Controller
                 }
             }
 
-            if ($asset->checkOut($target, $admin, $checkout_at, $company_id, e($request->get('note')), $request->get('name'))) {
+            if ($asset->checkOut($target, $admin, $checkout_at, $company_id, $status_id, e($request->get('note')), $request->get('name'))) {
                 return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.checkout.success'));
             }
 


### PR DESCRIPTION
FIXED:
- Single asset checkout throwing status_id error when adding notes to the checkout 

# Description
Single asset checkout was breaking when checking out a unit. This error only occurs when adding notes to the checkout. After testing and diagnostics, it was found that the status_id was not being passed through the $asset->checkOut() method but instead being set as a local variable on the $asset model ($assset->status_id = $request->get('status_id')). This caused an issue with the checkout due to the $notes variable in the checkOut() method being in the spot of the $status_id variable.

Fixes # (issue)
- Single asset checkout throwing status_id error when adding notes to the checkout 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Debian testing/staging environment
- [ ] Test B

**Test Configuration**:
* PHP version: 8.1.20
* MySQL version: 10.5.19
* Webserver version: Apache/2.4.56 (Debian)
* OS version: Debian 11


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
