### PR TITLE
Fixed broken update logs

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -198,7 +198,6 @@ class Asset extends Depreciable
      */
     public static function clearAudit(Asset $asset): void
     {
-        $asset->unsetEventDispatcher();
         $asset->next_audit_date = null;
         $asset->last_audit_date = date('Y-m-d H:i:s');
         if($asset->save()) {


### PR DESCRIPTION
# Description

Logs would not generate on an update if the status was set to Deployed or Delivered to Customer Site.
Additionally, if you updated an asset that already was set to Deployed or Delivered, it would generate an audit log instead of an update.

Fixed:
- Code now checks if the status is the same as the asset. Only changed status triggers an audit log if the criteria are met.
- Disabled the unsetEventDispatcher in the asset->logAudit() method. This was causing the update log to not trigger.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A Local windows dev env
- [x] Test B Staging env

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
